### PR TITLE
Visual Cue if No Events

### DIFF
--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -1,13 +1,17 @@
 import React, {Component} from 'react';
 import EventCard from './EventCard';
+import displayMessageNoEvents from '../functions/displayMessageNoEvents';
 
 class Home extends Component {
   render () {
     let data = this.props.filteredData
 
+    let message = displayMessageNoEvents(data)
+
     return (
       <section id='home-page'>
         <h2 className='sub-header'> HOME </h2>
+        <h4 className='event-message'> {message} </h4>
         {data.map(d =>
           <EventCard
             key={d.id}

--- a/src/components/TypeResults.js
+++ b/src/components/TypeResults.js
@@ -1,5 +1,6 @@
 import React, {Component} from 'react';
 import EventCard from './EventCard';
+import displayMessageNoEvents from '../functions/displayMessageNoEvents';
 
 class TypeResults extends Component {
   constructor() {
@@ -11,7 +12,6 @@ class TypeResults extends Component {
 
   componentWillMount() {
     this.filterByType()
-
   }
 
   filterByType() {
@@ -24,13 +24,14 @@ class TypeResults extends Component {
     this.setState({typeData: filteredType})
   }
 
-
-
   render(){
+
     let data = this.state.typeData
+    let message = displayMessageNoEvents(data)
+
     return (
       <section id='types-results-page'>
-
+        <h4 className='event-message'> {message} </h4>
         {data.map(d =>
           <EventCard
             key={d.id}

--- a/src/components/TypeResults.js
+++ b/src/components/TypeResults.js
@@ -11,6 +11,7 @@ class TypeResults extends Component {
 
   componentWillMount() {
     this.filterByType()
+
   }
 
   filterByType() {
@@ -23,10 +24,13 @@ class TypeResults extends Component {
     this.setState({typeData: filteredType})
   }
 
+
+
   render(){
     let data = this.state.typeData
     return (
       <section id='types-results-page'>
+
         {data.map(d =>
           <EventCard
             key={d.id}

--- a/src/functions/displayMessageNoEvents.js
+++ b/src/functions/displayMessageNoEvents.js
@@ -1,0 +1,7 @@
+  module.exports = function displayMessageNoEvents (data) {
+    if (data.length === 0) {
+      return 'no events';
+    } else {
+      return ''
+    }
+  }


### PR DESCRIPTION
This PR closes #38 . This PR adds a function to create a visual cue  ('no events' text) to display when there are no events found based on the filter parameters.
