### PR TITLE
Renders All Events with Type 'All'

### DIFF
--- a/src/components/TypeResults.js
+++ b/src/components/TypeResults.js
@@ -21,6 +21,15 @@ class TypeResults extends Component {
     let path = window.location.pathname
     let type = path.substr(path.lastIndexOf('/') + 1).replace("%20", " ")
     let data = this.props.filteredData
+
+    type === "All" ? this.returnAll(data) : this.returnType(data, type)  
+  }
+  
+  returnAll(data) {
+    this.setState({typeData: data})
+  }
+  
+  returnType(data, type) {
     let filteredType = data.filter((event) => {
       return event.event_type === type
     })


### PR DESCRIPTION
This closes #42.
This PR creates a conditional on the type results page, which returns all of the events if the all type is passed in, and filters by the type if another type is passed in.