### PR TITLE
Searches by all fields instead of just name

### DIFF
--- a/src/components/AllEvents.js
+++ b/src/components/AllEvents.js
@@ -20,7 +20,7 @@ class AllEvents extends Component {
     let { filteredData } = this.props
 
     let eventList = filteredData.map((d) => {
-      let results = d.id + d.name + d.date + d.time + d.description + d.city + d.state + d.location
+      let results = d.name + d.date + d.time + d.description + d.city + d.state + d.location
       return results.toLowerCase().includes(searchString.toLowerCase()) ?
       (<EventCard
         key={d.id}

--- a/src/components/AllEvents.js
+++ b/src/components/AllEvents.js
@@ -20,7 +20,8 @@ class AllEvents extends Component {
     let { filteredData } = this.props
 
     let eventList = filteredData.map((d) => {
-      return d.name.toLowerCase().includes(searchString.toLowerCase()) ?
+      let results = d.id + d.name + d.date + d.time + d.description + d.city + d.state + d.location
+      return results.toLowerCase().includes(searchString.toLowerCase()) ?
       (<EventCard
         key={d.id}
         id={d.id}

--- a/src/components/TypeResults.js
+++ b/src/components/TypeResults.js
@@ -44,7 +44,8 @@ class TypeResults extends Component {
     let { typeData, searchString } = this.state
 
     let eventList = typeData.map((d) => {
-      return d.name.toLowerCase().includes(searchString.toLowerCase()) ?
+      let results = d.id + d.name + d.date + d.time + d.description + d.city + d.state + d.location
+      return results.toLowerCase().includes(searchString.toLowerCase()) ?
       (<EventCard
         key={d.id}
         id={d.id}

--- a/src/components/TypeResults.js
+++ b/src/components/TypeResults.js
@@ -44,7 +44,7 @@ class TypeResults extends Component {
     let { typeData, searchString } = this.state
 
     let eventList = typeData.map((d) => {
-      let results = d.id + d.name + d.date + d.time + d.description + d.city + d.state + d.location
+      let results = d.name + d.date + d.time + d.description + d.city + d.state + d.location
       return results.toLowerCase().includes(searchString.toLowerCase()) ?
       (<EventCard
         key={d.id}


### PR DESCRIPTION
This closes #49.
This PR makes the search function filter through the whole event card instead of just the event name.