### PR TITLE
Creates an All Location, Changes Search Function to Search through All Fields

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -36,6 +36,7 @@ class App extends Component {
   setLocation (option) {
     this.setState({location: option}, () => {
       let location = this.state.location.value;
+      location === 'All' ? this.setState({filteredData: this.state.data}) :
       this.filterEventByLocation(location)
     }
   )}

--- a/src/components/AllEvents.js
+++ b/src/components/AllEvents.js
@@ -20,7 +20,7 @@ class AllEvents extends Component {
     let { filteredData } = this.props
 
     let eventList = filteredData.map((d) => {
-      let results = d.id + d.name + d.date + d.time + d.description + d.city + d.state + d.location
+      let results = d.name + d.date + d.time + d.description + d.city + d.state + d.location
       return results.toLowerCase().includes(searchString.toLowerCase()) ?
       (<EventCard
         key={d.id}

--- a/src/components/AllEvents.js
+++ b/src/components/AllEvents.js
@@ -20,7 +20,8 @@ class AllEvents extends Component {
     let { filteredData } = this.props
 
     let eventList = filteredData.map((d) => {
-      return d.name.toLowerCase().includes(searchString.toLowerCase()) ?
+      let results = d.id + d.name + d.date + d.time + d.description + d.city + d.state + d.location
+      return results.toLowerCase().includes(searchString.toLowerCase()) ?
       (<EventCard
         key={d.id}
         id={d.id}

--- a/src/components/TypeResults.js
+++ b/src/components/TypeResults.js
@@ -44,7 +44,8 @@ class TypeResults extends Component {
     let { typeData, searchString } = this.state
 
     let eventList = typeData.map((d) => {
-      return d.name.toLowerCase().includes(searchString.toLowerCase()) ?
+      let results = d.id + d.name + d.date + d.time + d.description + d.city + d.state + d.location
+      return results.toLowerCase().includes(searchString.toLowerCase()) ?
       (<EventCard
         key={d.id}
         id={d.id}

--- a/src/components/TypeResults.js
+++ b/src/components/TypeResults.js
@@ -44,7 +44,7 @@ class TypeResults extends Component {
     let { typeData, searchString } = this.state
 
     let eventList = typeData.map((d) => {
-      let results = d.id + d.name + d.date + d.time + d.description + d.city + d.state + d.location
+      let results = d.name + d.date + d.time + d.description + d.city + d.state + d.location
       return results.toLowerCase().includes(searchString.toLowerCase()) ?
       (<EventCard
         key={d.id}

--- a/states.js
+++ b/states.js
@@ -1,4 +1,5 @@
 const options = [
+  {label: 'All', value: 'All'},
   {label: 'Alabama', value: 'AL' },
   {label: 'Alaska', value: 'AK' },
   {label: 'Arizona', value: 'AZ' },


### PR DESCRIPTION
This closes #49.
This closes #57.
This PR allows the search function to filter through all of the fields in the event cards instead of just the event names.
It also creates a location 'all' which allows users to display all events.